### PR TITLE
Fix missing tar during dev container build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@ FROM store/softwareag/apama-builder:${APAMA_VERSION}
 USER root
 RUN microdnf install git
 RUN microdnf install python3
+RUN microdnf install tar
 
 WORKDIR "/usr/local/bin"
 COPY apama apama


### PR DESCRIPTION
In windows I get the error during container build that tar is not installed.
Adding tar to dockerfile fix this.