### PR TITLE
feat: make it easier to change image 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 ARG APAMA_VERSION
-FROM public.ecr.aws/apama/apama-builder:${APAMA_VERSION}
+ARG APAMA_IMAGE
+FROM ${APAMA_IMAGE}:${APAMA_VERSION}
 
 USER root
 RUN microdnf install git tar -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
+			"APAMA_IMAGE": "public.ecr.aws/apama/apama-builder",
 			"APAMA_VERSION": "10.15-ubi9",
 			"APAMA_ANALYTICS_BUILDER_SDK_BRANCH": "main",
 			"APAMA_EPLAPPS_TOOLS_BRANCH": "main"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Replacing `<URL>`, `<USERNAME>` and `<PASSWORD>` with the correct values.
 
 3. When you need to perform a Block SDK operation, run `source .env` within your terminal. This will create a terminal instance with the relevant environment variables for authenticating to Cumulocity.
 
+
+## Usage notes
+- You may find the default memory allocated by your containerization tool is not sufficient. We advise having a minimum of 4GB of memory for local development. 
+
 ## Legal notices
 Prior to executing the Docker Pull Command, downloading, using or installing the accompanying software product, please ensure to read and accept the terms applying to this offering:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Before you build the devcontainer, you might want to adjust some of the values w
 
 | Parameter                             | Description                                               | Comments                                      |
 | -------------                         |:-------------:                                            | -----:                                        |
-| APAMA_VERSION                         | the tag of the Apama base container                       | Please see [Amazon ECR](https://gallery.ecr.aws/apama/apama-builder) for available versions  |
+| APAMA_IMAGE                           | the Apama Docker image to use                             | Please see [Amazon ECR](https://gallery.ecr.aws/apama) for available images. Note: on versions older than 26, we advise using `public.ecr.aws/apama/apama-cumulocity-builder`. | 
+| APAMA_VERSION                         | the tag of the Apama base container                       | Please see [Amazon ECR](https://gallery.ecr.aws/apama/apama-builder) for available versions.  |
 | APAMA_ANALYTICS_BUILDER_SDK_BRANCH    | the branch/version of the Analytics Builder SDK           | Please see [Github](https://github.com/Cumulocity-IoT/apama-analytics-builder-block-sdk) for the available branches  |
 | APAMA_EPLAPPS_TOOLS_BRANCH            | the branch/version of the EPL Apps Tools SDK              | Please see [Github](https://github.com/Cumulocity-IoT/apama-eplapps-tools) for the available branches  |
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before you build the devcontainer, you might want to adjust some of the values w
 __*Note:*__ The Analytics Builder SDK needs to be in the same version as the Apama in the Cloud when you want to deploy. 
 
 ## Using Block SDK & EPLApps Tools
-The Block SDK & EPLApps Tools are checked out as siblings to your current workspace folder. This allows you to easily add bundles from either of those projects using `apama_project` (which is accessible from the VSCode extension), or to simply use the, or to simply use them.
+The Block SDK & EPLApps Tools are checked out as siblings to your current workspace folder. This allows you to easily add bundles from either of those projects using `apama_project` (which is accessible from the VSCode extension), or to simply use them.
 
 ### Block SDK cloud operations
 For commands in the Block SDK that require Cloud access, such as "upload", we recommend using a `.env` file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This repository specifies a [development container](https://containers.dev/overview), suitable for use for standard Apama development, or for working with the [Block SDK](https://github.com/Cumulocity-IoT/apama-analytics-builder-block-sdk) & [EPL Apps Tools](https://github.com/Cumulocity-IoT/apama-eplapps-tools).
 
 ## Instructions
-To use this, you can can either fork this repository, or copy the `.devcontainer` directory into your existing project. Use your DevContainer tool of choice (e.g. [Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers)) to run this.
+To use this, you can either fork this repository, or copy the `.devcontainer` directory into your existing project. Use your DevContainer tool of choice (e.g. [Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers)) to run this.
 
 ### Before you build
 Before you build the devcontainer, you might want to adjust some of the values within `.devcontainer/devcontainer.json`.


### PR DESCRIPTION
- On 10.15, you'll want to use `apama-cumulocity-builder`, not `apama-builder`. On 26.x, the other way around.
- We've given some advice on how to do so, and made it easier to make that image change.
- Also, while testing, noticed some issues with low memory. Added a note to help users here.