### PR TITLE
Update for 26.x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ ARG APAMA_VERSION
 ARG APAMA_IMAGE
 FROM ${APAMA_IMAGE}:${APAMA_VERSION}
 
-ARG USERNAME=apama-container
+ARG USERNAME=apama
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
@@ -12,8 +12,8 @@ RUN apt update && apt install git tar -y
 # The mount location.
 RUN mkdir "/workspaces"
 
-RUN groupadd --gid ${USER_GID} ${USERNAME} \
-    && useradd --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} -m \
+RUN groupmod --gid ${USER_GID} ${USERNAME} \
+    && usermod --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} -d "/home/apama" -m \
     && chown -R ${USER_UID}:${USER_GID} /workspaces \
     && chown -R ${USER_UID}:${USER_GID} /home/${USERNAME}
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,21 +2,22 @@ ARG APAMA_VERSION
 ARG APAMA_IMAGE
 FROM ${APAMA_IMAGE}:${APAMA_VERSION}
 
-ARG USERNAME=apama
+ARG USERNAME=apama-container
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
 USER root
-RUN microdnf install git tar -y
+RUN apt update && apt install git tar -y
 
 # The mount location.
 RUN mkdir "/workspaces"
 
-RUN groupmod --gid ${USER_GID} ${USERNAME} \
-    && usermod --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} \
-    && chown -R ${USER_UID}:${USER_GID} /workspaces
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} -m \
+    && chown -R ${USER_UID}:${USER_GID} /workspaces \
+    && chown -R ${USER_UID}:${USER_GID} /home/${USERNAME}
 
-USER apama 
+USER ${USERNAME}
 WORKDIR "/workspaces"
 
 # Check out Block SDK at the mount location.
@@ -32,6 +33,5 @@ RUN git clone https://github.com/Cumulocity-IoT/apama-eplapps-tools.git
 ARG APAMA_EPLAPPS_TOOLS_BRANCH
 WORKDIR "/workspaces/apama-eplapps-tools"
 RUN git checkout ${APAMA_EPLAPPS_TOOLS_BRANCH}
-
 
 ENV SHELL=/bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,5 @@
 		}
 	},
 	"overrideCommand": true,
-	"remoteUser": "apama-container"
+	"remoteUser": "apama"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,5 @@
 		}
 	},
 	"overrideCommand": true,
-	"remoteUser": "apama"
+	"remoteUser": "apama-container"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": { 
 			"APAMA_IMAGE": "public.ecr.aws/apama/apama-builder",
-			"APAMA_VERSION": "10.15-ubi9",
+			"APAMA_VERSION": "latest",
 			"APAMA_ANALYTICS_BUILDER_SDK_BRANCH": "main",
 			"APAMA_EPLAPPS_TOOLS_BRANCH": "main"
 		}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 This repository specifies a [development container](https://containers.dev/overview), suitable for use for standard Apama development, or for working with the [Block SDK](https://github.com/Cumulocity-IoT/apama-analytics-builder-block-sdk) & [EPL Apps Tools](https://github.com/Cumulocity-IoT/apama-eplapps-tools).
 
-This version of the development container is for the 10.15 branch of Apama.
+This version of the development container is for the 26.x branch of Apama. Please see the `10.15` branch for running this on older lines.
 
 ## Instructions
 To use this, you can either fork this repository, or copy the `.devcontainer` directory into your existing project. Use your DevContainer tool of choice (e.g. [Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers)) to run this.
@@ -13,8 +13,8 @@ Before you build the devcontainer, you might want to adjust some of the values w
 
 | Parameter                             | Description                                               | Comments                                      |
 | -------------                         |:-------------:                                            | -----:                                        |
-| APAMA_IMAGE                           | the Apama Docker image to use                             | Please see [Amazon ECR](https://gallery.ecr.aws/apama) for available images. Note: the Dockerfile on this version of the branch is only compatible with RHEL UBI images.  | 
-| APAMA_VERSION                         | the tag of the Apama base container                       | Please see [Amazon ECR](https://gallery.ecr.aws/apama/apama-builder) for available versions. Note: the Dockerfile on this version of the branch is only compatible with RHEL UBI images.  |
+| APAMA_IMAGE                           | the Apama Docker image to use                             | Please see [Amazon ECR](https://gallery.ecr.aws/apama) for available images. Note: the Dockerfile on this version of the branch is only compatible with Debian-based images.  | 
+| APAMA_VERSION                         | the tag of the Apama base container                       | Please see [Amazon ECR](https://gallery.ecr.aws/apama/apama-builder) for available versions. Note: the Dockerfile on this version of the branch is only compatible with Debian-based images.  |
 | APAMA_ANALYTICS_BUILDER_SDK_BRANCH    | the branch/version of the Analytics Builder SDK           | Please see [Github](https://github.com/Cumulocity-IoT/apama-analytics-builder-block-sdk) for the available branches  |
 | APAMA_EPLAPPS_TOOLS_BRANCH            | the branch/version of the EPL Apps Tools SDK              | Please see [Github](https://github.com/Cumulocity-IoT/apama-eplapps-tools) for the available branches  |
 


### PR DESCRIPTION
- Support 26.x on the DevContainer,
- We also modify the `apama` user to have a more normal directory of `/home/apama`, instead of `/opt/Cumulocity`. It has to be chowned so that VSCode can write into it. 