### PR TITLE
feat: set `apama-cumulocity-builder` to be the default image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			"APAMA_IMAGE": "public.ecr.aws/apama/apama-builder",
+			"APAMA_IMAGE": "public.ecr.aws/apama/apama-cumulocity-builder",
 			"APAMA_VERSION": "10.15-ubi9",
 			"APAMA_ANALYTICS_BUILDER_SDK_BRANCH": "main",
 			"APAMA_EPLAPPS_TOOLS_BRANCH": "main"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before you build the devcontainer, you might want to adjust some of the values w
 
 | Parameter                             | Description                                               | Comments                                      |
 | -------------                         |:-------------:                                            | -----:                                        |
-| APAMA_IMAGE                           | the Apama Docker image to use                             | Please see [Amazon ECR](https://gallery.ecr.aws/apama) for available images. Note: on versions older than 26, we advise using `public.ecr.aws/apama/apama-cumulocity-builder`. | 
+| APAMA_IMAGE                           | the Apama Docker image to use                             | Please see [Amazon ECR](https://gallery.ecr.aws/apama) for available images.  | 
 | APAMA_VERSION                         | the tag of the Apama base container                       | Please see [Amazon ECR](https://gallery.ecr.aws/apama/apama-builder) for available versions.  |
 | APAMA_ANALYTICS_BUILDER_SDK_BRANCH    | the branch/version of the Analytics Builder SDK           | Please see [Github](https://github.com/Cumulocity-IoT/apama-analytics-builder-block-sdk) for the available branches  |
 | APAMA_EPLAPPS_TOOLS_BRANCH            | the branch/version of the EPL Apps Tools SDK              | Please see [Github](https://github.com/Cumulocity-IoT/apama-eplapps-tools) for the available branches  |


### PR DESCRIPTION
we're going to have to create a `10.15` branch because the dockerfile has to change for debian 12.

this is fine, but it then makes no sense to "prepare" for 26.x